### PR TITLE
#40 やっと終了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 # Ignore uploaded files in development
 /public/uploads/
 /public/uploads_test/
+
+#aws関連の環境変数を除外
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'mini_magick'
 #AWS s3
 gem 'fog-aws'
 gem 'kaminari'
+gem 'dotenv-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,10 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    dotenv (2.7.2)
+    dotenv-rails (2.7.2)
+      dotenv (= 2.7.2)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     excon (0.64.0)
     execjs (2.7.0)
@@ -245,6 +249,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   carrierwave
   coffee-rails (~> 4.2)
+  dotenv-rails
   factory_bot_rails (~> 4.10.0)
   fog-aws
   jbuilder (~> 2.5)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,9 +6,16 @@ CarrierWave.configure do |config|
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
     region: ENV['AWS_REGION'],
   }
+  case Rails.env
+    when 'production'
+      config.fog_directory = 's3-yuiyuicom'
 
-  config.fog_directory = 'yuiyuicom'
+    when 'development'
+      config.fog_directory = 'dev-s3-yuiyuicom'
+
+    when 'test'
+      config.fog_directory = 'dev-s3-yuiyuicom'
+  end
 end
 
-# 日本語ファイル名の設定
 CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,31 +5,9 @@ CarrierWave.configure do |config|
     aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
     region: ENV['AWS_REGION'],
-    path_style: true
   }
 
-  # 公開・非公開の切り替え
-  config.fog_public     = true
-  # キャッシュの保存期間
-  config.fog_attributes = { 'Cache-Control' => "max-age=#{30.day.to_i}" }
-
-  # キャッシュをS3に保存
-  # config.cache_storage = :fog
-
-  # 環境ごとにS3のバケットを指定
-  case Rails.env
-    when 'production'
-      config.fog_directory = 'yuiyuicom'
-      config.asset_host = 'https://yuiyuicom.s3-ap-northeast-1.amazonaws.com'
-
-    when 'development'
-      config.fog_directory = 'dev-yuiyuicom'
-      config.asset_host = 'https://dev-yuiyuicom.s3-ap-northeast-1.amazonaws.com'
-
-    when 'test'
-      config.fog_directory = 'dev-yuiyuicom'
-      config.asset_host = 'https://dev-yuiyuicom.s3-ap-northeast-1.amazonaws.com'
-  end
+  config.fog_directory = 'yuiyuicom'
 end
 
 # 日本語ファイル名の設定


### PR DESCRIPTION
- aws s3の導入確認するために、わざわざCI通す意味がなかった。

- s3の導入テストはローカル環境でできる。本番環境でやらなくてもよかった。